### PR TITLE
Preserving whitespaces as string tokens

### DIFF
--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -28,7 +28,8 @@ element {
   Parens { ParenL element* ParenR } |
   Braces { BraceL element* BraceR } |
   Brackets { BracketL element* BracketR } |
-  Resolvable
+  Resolvable |
+  Whitespace
 }
 
 @tokens {
@@ -72,6 +73,7 @@ element {
   Bits
   Bytes
   Builtin
+  Whitespace
 }
 
 @detectDelim

--- a/src/sql.grammar.terms.d.ts
+++ b/src/sql.grammar.terms.d.ts
@@ -1,4 +1,4 @@
-export const whitespace: number, LineComment: number, BlockComment: number,
+export const Whitespace: number, LineComment: number, BlockComment: number,
   String: number, Number: number, Bool: number, Null: number,
   ParenL: number, ParenR: number, BraceL: number, BraceR: number, BracketL: number, BracketR: number, Semi: number, Dot: number,
   Operator: number, Punctuation: number, SpecialVar: number, Identifier: number, QuotedIdentifier: number,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,7 +2,7 @@ import {ExternalTokenizer, InputStream} from "@lezer/lr"
 import {LineComment, BlockComment, String as StringToken, Number, Bits, Bytes, Bool, Null,
         ParenL, ParenR, BraceL, BraceR, BracketL, BracketR, Semi, Dot,
         Operator, Punctuation, SpecialVar, Identifier, QuotedIdentifier,
-        Keyword, Type, Builtin} from "./sql.grammar.terms"
+        Keyword, Type, Builtin, Whitespace} from "./sql.grammar.terms"
 
 const enum Ch {
   Newline = 10,
@@ -176,7 +176,7 @@ export function tokensFor(d: Dialect) {
     let {next} = input
     input.advance()
     if (inString(next, Space)) {
-      input.acceptToken(StringToken)
+      input.acceptToken(Whitespace)
     } else if (next == Ch.Dollar && input.next == Ch.Dollar && d.doubleDollarQuotedStrings) {
       readDoubleDollarLiteral(input)
       input.acceptToken(StringToken)

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -176,6 +176,7 @@ export function tokensFor(d: Dialect) {
     let {next} = input
     input.advance()
     if (inString(next, Space)) {
+      while (inString(input.next, Space)) input.advance()
       input.acceptToken(Whitespace)
     } else if (next == Ch.Dollar && input.next == Ch.Dollar && d.doubleDollarQuotedStrings) {
       readDoubleDollarLiteral(input)

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -176,7 +176,7 @@ export function tokensFor(d: Dialect) {
     let {next} = input
     input.advance()
     if (inString(next, Space)) {
-      while (inString(input.next, Space)) input.advance()
+      input.acceptToken(StringToken)
     } else if (next == Ch.Dollar && input.next == Ch.Dollar && d.doubleDollarQuotedStrings) {
       readDoubleDollarLiteral(input)
       input.acceptToken(StringToken)

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -11,11 +11,11 @@ describe("Parse MySQL tokens", () => {
   const parser = mysqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bits))')
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
   it("parses unquoted bit-value literals", () => {
-    ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,String,Bits))')
+    ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 })
 
@@ -23,15 +23,15 @@ describe("Parse PostgreSQL tokens", () => {
   const parser = postgresqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bits))')
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,String,Bits))')
+    ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
-  it("parses double dollar quoted string literals", () => {
-    ist(parser.parse("SELECT $$hello$$"), 'Script(Statement(Keyword,String,String))')
+  it("parses double dollar quoted Whitespace literals", () => {
+    ist(parser.parse("SELECT $$hello$$"), 'Script(Statement(Keyword,Whitespace,String))')
   })
 })
 
@@ -39,19 +39,19 @@ describe("Parse BigQuery tokens", () => {
   const parser = bigQueryTokens.parser
 
   it("parses quoted bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,String,Bytes))')
+    ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses quoted bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,String,Bytes))')
+    ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bytes))')
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,String,Bytes))')
+    ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 })
 
@@ -59,22 +59,22 @@ describe("Parse n8n resolvables", () => {
   const parser = postgresqlTokens.parser
 
   it("parses 4-node SELECT variants", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table"), 'Script(Statement(Resolvable,String,Identifier,String,Keyword,String,Identifier))')
+    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table"), 'Script(Statement(Resolvable,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Identifier))')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table"), 'Script(Statement(Keyword,String,Resolvable,String,Keyword,String,Identifier))')
+    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table"), 'Script(Statement(Keyword,Whitespace,Resolvable,Whitespace,Keyword,Whitespace,Identifier))')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table"), 'Script(Statement(Keyword,String,Identifier,String,Resolvable,String,Identifier))')
+    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Resolvable,Whitespace,Identifier))')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }}"), 'Script(Statement(Keyword,String,Identifier,String,Keyword,String,Resolvable))')
+    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }}"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Resolvable))')
   })
 
   it("parses 5-node SELECT variants (with semicolon)", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table;"), 'Script(Statement(Resolvable,String,Identifier,String,Keyword,String,Identifier,";"))')
+    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table;"), 'Script(Statement(Resolvable,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Identifier,";"))')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table;"), 'Script(Statement(Keyword,String,Resolvable,String,Keyword,String,Identifier,";"))')
+    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table;"), 'Script(Statement(Keyword,Whitespace,Resolvable,Whitespace,Keyword,Whitespace,Identifier,";"))')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table;"), 'Script(Statement(Keyword,String,Identifier,String,Resolvable,String,Identifier,";"))')
+    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table;"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Resolvable,Whitespace,Identifier,";"))')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }};"), 'Script(Statement(Keyword,String,Identifier,String,Keyword,String,Resolvable,";"))')
+    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }};"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Resolvable,";"))')
   })
 })

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -11,11 +11,13 @@ describe("Parse MySQL tokens", () => {
   const parser = mysqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bits))')
+    console.log(parser.parse("SELECT b'0101' \n\t FROM my_table").toString());
+    
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bits))')
   })
 
   it("parses unquoted bit-value literals", () => {
-    ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,Bits))')
+    ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,String,Bits))')
   })
 })
 
@@ -23,15 +25,15 @@ describe("Parse PostgreSQL tokens", () => {
   const parser = postgresqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bits))')
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bits))')
   })
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,Bits))')
+    ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,String,Bits))')
   })
 
   it("parses double dollar quoted string literals", () => {
-    ist(parser.parse("SELECT $$hello$$"), 'Script(Statement(Keyword,String))')
+    ist(parser.parse("SELECT $$hello$$"), 'Script(Statement(Keyword,String,String))')
   })
 })
 
@@ -39,19 +41,19 @@ describe("Parse BigQuery tokens", () => {
   const parser = bigQueryTokens.parser
 
   it("parses quoted bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,Bytes))')
+    ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,String,Bytes))')
   })
 
   it("parses quoted bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,Bytes))')
+    ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,String,Bytes))')
   })
 
   it("parses bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bytes))')
+    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bytes))')
   })
 
   it("parses bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,Bytes))')
+    ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,String,Bytes))')
   })
 })
 
@@ -59,22 +61,22 @@ describe("Parse n8n resolvables", () => {
   const parser = postgresqlTokens.parser
 
   it("parses 4-node SELECT variants", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table"), 'Script(Statement(Resolvable,Identifier,Keyword,Identifier))')
+    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table"), 'Script(Statement(Resolvable,String,Identifier,String,Keyword,String,Identifier))')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table"), 'Script(Statement(Keyword,Resolvable,Keyword,Identifier))')
+    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table"), 'Script(Statement(Keyword,String,Resolvable,String,Keyword,String,Identifier))')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table"), 'Script(Statement(Keyword,Identifier,Resolvable,Identifier))')
+    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table"), 'Script(Statement(Keyword,String,Identifier,String,Resolvable,String,Identifier))')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }}"), 'Script(Statement(Keyword,Identifier,Keyword,Resolvable))')
+    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }}"), 'Script(Statement(Keyword,String,Identifier,String,Keyword,String,Resolvable))')
   })
 
   it("parses 5-node SELECT variants (with semicolon)", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table;"), 'Script(Statement(Resolvable,Identifier,Keyword,Identifier,";"))')
+    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table;"), 'Script(Statement(Resolvable,String,Identifier,String,Keyword,String,Identifier,";"))')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table;"), 'Script(Statement(Keyword,Resolvable,Keyword,Identifier,";"))')
+    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table;"), 'Script(Statement(Keyword,String,Resolvable,String,Keyword,String,Identifier,";"))')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table;"), 'Script(Statement(Keyword,Identifier,Resolvable,Identifier,";"))')
+    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table;"), 'Script(Statement(Keyword,String,Identifier,String,Resolvable,String,Identifier,";"))')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }};"), 'Script(Statement(Keyword,Identifier,Keyword,Resolvable,";"))')
+    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }};"), 'Script(Statement(Keyword,String,Identifier,String,Keyword,String,Resolvable,";"))')
   })
 })

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -11,8 +11,6 @@ describe("Parse MySQL tokens", () => {
   const parser = mysqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    console.log(parser.parse("SELECT b'0101' \n\t FROM my_table").toString());
-    
     ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,String,Bits))')
   })
 


### PR DESCRIPTION
Extending the grammar so it preserves whitespaces in the parsed output as string tokens. This will enable us to get correctly formatted expression preview in n8n SQL editor:
![image](https://github.com/n8n-io/codemirror-lang-n8n-sql/assets/2598782/ff1355c1-716a-4058-b3a5-2e680c92474a)

In order to achieve this, following changes were made compared to `master`:

1.  Parsing logic is updated so new `StringToken` is accepted whenever a whitespace i s encountered
2. Parsing logic that extracts table aliases is updated so empty string tokens are skipped
3. Token tests are updated to account for extra String tokens in the output

NOTE: I haven't managed to make the parser use something more meaningful except the `StringToken` for whitespaces, hence this approach :)