### PR TITLE
fix: Use language overlay and highlight functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@n8n/codemirror-lang-sql",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@n8n/codemirror-lang-sql",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -16,7 +16,8 @@
         "@lezer/lr": "^1.0.0"
       },
       "devDependencies": {
-        "@codemirror/buildhelper": "^0.1.5"
+        "@codemirror/buildhelper": "^0.1.5",
+        "@codemirror/text": "^0.19.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -272,6 +273,14 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
       "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
+    },
+    "node_modules/@codemirror/text": {
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
+      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/view": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@lezer/lr": "^1.0.0"
   },
   "devDependencies": {
-    "@codemirror/buildhelper": "^0.1.5"
+    "@codemirror/buildhelper": "^0.1.5",
+    "@codemirror/text": "^0.19.6"
   },
   "repository": {
     "type": "git",

--- a/src/expressions.grammar
+++ b/src/expressions.grammar
@@ -1,0 +1,21 @@
+@top Program { entity* }
+
+entity { Plaintext | Resolvable }
+
+@tokens {
+  Plaintext { ![{] Plaintext? | "{" (@eof | ![{] Plaintext?) }
+
+  OpenMarker[closedBy="CloseMarker"] { "{{" }
+
+  CloseMarker[openedBy="OpenMarker"] { "}}" }
+
+  Resolvable {
+    OpenMarker resolvableChar* CloseMarker
+  }
+
+  resolvableChar { unicodeChar | "}" ![}] | "\\}}" }
+
+  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u2700-\u27BF] | $[\u{1F300}-\u{1FAF8}] | $[\u4E00-\u9FFF] }
+}
+
+@detectDelim

--- a/src/expressions.grammar.d.ts
+++ b/src/expressions.grammar.d.ts
@@ -1,0 +1,2 @@
+import {LRParser} from "@lezer/lr"
+export declare const parser: LRParser

--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -5,7 +5,7 @@
   Statement { element+ }?
 }
 
-@skip { LineComment | BlockComment }
+@skip { Whitespace | LineComment | BlockComment }
 
 element {
   String |
@@ -19,7 +19,7 @@ element {
   Builtin |
   SpecialVar |
   CompositeIdentifier {
-    Dot? (QuotedIdentifier | Identifier | SpecialVar | Resolvable) (!dot Dot (QuotedIdentifier | Identifier | SpecialVar | Resolvable))+
+    Dot? (QuotedIdentifier | Identifier | SpecialVar) (!dot Dot (QuotedIdentifier | Identifier | SpecialVar))+
   } |
   Keyword |
   Type |
@@ -27,33 +27,11 @@ element {
   Punctuation |
   Parens { ParenL element* ParenR } |
   Braces { BraceL element* BraceR } |
-  Brackets { BracketL element* BracketR } |
-  orphanWrappedResolvable {
-    (OrphanSingleQuote Whitespace? Resolvable Whitespace? OrphanSingleQuote)
-  } |
-  Resolvable |
-  Whitespace
-}
-
-@tokens {
-  OrphanSingleQuote { "'" }
-
-  Resolvable { ResolvableStart resolvableContent* ResolvableEnd }
-
-  ResolvableStart[closedBy="ResolvableEnd"] { "{{" }
-
-  ResolvableEnd[openedBy="ResolvableStart"] { "}}" }
-
-  resolvableContent {
-    unicodeChar |
-    "}" ![}] |
-    "\\}}"
-  }
-
-  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u06FF] }
+  Brackets { BracketL element* BracketR }
 }
 
 @external tokens tokens from "./tokens" {
+  Whitespace
   LineComment
   BlockComment
   String
@@ -78,7 +56,6 @@ element {
   Bits
   Bytes
   Builtin
-  Whitespace
 }
 
 @detectDelim

--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -28,6 +28,7 @@ element {
   Parens { ParenL element* ParenR } |
   Braces { BraceL element* BraceR } |
   Brackets { BracketL element* BracketR }
+  Function
 }
 
 @external tokens tokens from "./tokens" {
@@ -56,6 +57,7 @@ element {
   Bits
   Bytes
   Builtin
+  Function
 }
 
 @detectDelim

--- a/src/sql.grammar.terms.d.ts
+++ b/src/sql.grammar.terms.d.ts
@@ -2,4 +2,4 @@ export const Whitespace: number, LineComment: number, BlockComment: number,
   String: number, Number: number, Bool: number, Null: number,
   ParenL: number, ParenR: number, BraceL: number, BraceR: number, BracketL: number, BracketR: number, Semi: number, Dot: number,
   Operator: number, Punctuation: number, SpecialVar: number, Identifier: number, QuotedIdentifier: number,
-  Keyword: number, Type: number, Builtin: number, Bits: number, Bytes: number
+  Keyword: number, Type: number, Builtin: number, Bits: number, Bytes: number, Function: number

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -5,7 +5,7 @@ import {styleTags, tags as t} from "@lezer/highlight"
 import {parser as baseParser} from "./sql.grammar"
 import {parser as expressionParser} from "./expressions.grammar"
 import {parseMixed} from "@lezer/common"
-import {tokens, Dialect, tokensFor, SQLKeywords, SQLTypes, dialect} from "./tokens"
+import {tokens, Dialect, tokensFor, SQLKeywords, SQLTypes, dialect, SQLFunctions} from "./tokens"
 import {completeFromSchema, completeKeywords} from "./complete"
 
 
@@ -35,6 +35,7 @@ const getSqlParser = () => {
         LineComment: t.lineComment,
         BlockComment: t.blockComment,
         Operator: t.operator,
+        Function: t.function(t.variableName),
         "Semi Punctuation": t.punctuation,
         "( )": t.paren,
         "{ }": t.brace,
@@ -75,44 +76,12 @@ export const getParser = (dialect: Dialect) => {
   return {mixedLanguage, sqlLanguage}
 }
 
-
-let parser = baseParser.configure({
-  props: [
-    indentNodeProp.add({
-      Statement: continuedIndent()
-    }),
-    foldNodeProp.add({
-      Statement(tree) { return {from: tree.firstChild!.to, to: tree.to} },
-      BlockComment(tree) { return {from: tree.from + 2, to: tree.to - 2} }
-    }),
-    styleTags({
-      Keyword: t.keyword,
-      Type: t.typeName,
-      Builtin: t.standard(t.name),
-      Bits: t.number,
-      Bytes: t.string,
-      Bool: t.bool,
-      Null: t.null,
-      Number: t.number,
-      String: t.string,
-      Identifier: t.name,
-      QuotedIdentifier: t.special(t.string),
-      SpecialVar: t.special(t.name),
-      LineComment: t.lineComment,
-      BlockComment: t.blockComment,
-      Operator: t.operator,
-      "Semi Punctuation": t.punctuation,
-      "( )": t.paren,
-      "{ }": t.brace,
-      "[ ]": t.squareBracket
-    })
-  ]
-})
-
 /// Configuration for an [SQL Dialect](#lang-sql.SQLDialect).
 export type SQLDialectSpec = {
   /// A space-separated list of keywords for the dialect.
   keywords?: string,
+  /// A space-separated list of functions for the dialect.
+  functions?: string,
   /// A space-separated string of built-in identifiers for the dialect.
   builtin?: string,
   /// A space-separated string of type names for the dialect.
@@ -169,7 +138,7 @@ export class SQLDialect {
 
   /// Define a new dialect.
   static define(spec: SQLDialectSpec) {
-    let d = dialect(spec, spec.keywords, spec.types, spec.builtin)
+    let d = dialect(spec, spec.keywords, spec.types, spec.builtin, spec.functions)
     const {mixedLanguage, sqlLanguage} = getParser(d)
     let language = mixedLanguage
     return new SQLDialect(d, language, spec, sqlLanguage)
@@ -249,7 +218,8 @@ export const PostgreSQL = SQLDialect.define({
   doubleDollarQuotedStrings: true,
   operatorChars: "+-*/<>=~!@#%^&|`?",
   specialVar: "",
-  keywords: SQLKeywords + "a abort abs absent access according ada admin aggregate alias also always analyse analyze array_agg array_max_cardinality asensitive assert assignment asymmetric atomic attach attribute attributes avg backward base64 begin_frame begin_partition bernoulli bit_length blocked bom c cache called cardinality catalog_name ceil ceiling chain char_length character_length character_set_catalog character_set_name character_set_schema characteristics characters checkpoint class class_origin cluster coalesce cobol collation_catalog collation_name collation_schema collect column_name columns command_function command_function_code comment comments committed concurrently condition_number configuration conflict connection_name constant constraint_catalog constraint_name constraint_schema contains content control conversion convert copy corr cost covar_pop covar_samp csv cume_dist current_catalog current_row current_schema cursor_name database datalink datatype datetime_interval_code datetime_interval_precision db debug defaults defined definer degree delimiter delimiters dense_rank depends derived detach detail dictionary disable discard dispatch dlnewcopy dlpreviouscopy dlurlcomplete dlurlcompleteonly dlurlcompletewrite dlurlpath dlurlpathonly dlurlpathwrite dlurlscheme dlurlserver dlvalue document dump dynamic_function dynamic_function_code element elsif empty enable encoding encrypted end_frame end_partition endexec enforced enum errcode error event every exclude excluding exclusive exp explain expression extension extract family file filter final first_value flag floor following force foreach fortran forward frame_row freeze fs functions fusion g generated granted greatest groups handler header hex hierarchy hint id ignore ilike immediately immutable implementation implicit import include including increment indent index indexes info inherit inherits inline insensitive instance instantiable instead integrity intersection invoker isnull k key_member key_type label lag last_value lead leakproof least length library like_regex link listen ln load location lock locked log logged lower m mapping matched materialized max max_cardinality maxvalue member merge message message_length message_octet_length message_text min minvalue mod mode more move multiset mumps name namespace nfc nfd nfkc nfkd nil normalize normalized nothing notice notify notnull nowait nth_value ntile nullable nullif nulls number occurrences_regex octet_length octets off offset oids operator options ordering others over overlay overriding owned owner p parallel parameter_mode parameter_name parameter_ordinal_position parameter_specific_catalog parameter_specific_name parameter_specific_schema parser partition pascal passing passthrough password percent percent_rank percentile_cont percentile_disc perform period permission pg_context pg_datatype_name pg_exception_context pg_exception_detail pg_exception_hint placing plans pli policy portion position position_regex power precedes preceding prepared print_strict_params procedural procedures program publication query quote raise range rank reassign recheck recovery refresh regr_avgx regr_avgy regr_count regr_intercept regr_r2 regr_slope regr_sxx regr_sxy regr_syy reindex rename repeatable replace replica requiring reset respect restart restore result_oid returned_cardinality returned_length returned_octet_length returned_sqlstate returning reverse routine_catalog routine_name routine_schema routines row_count row_number rowtype rule scale schema_name schemas scope scope_catalog scope_name scope_schema security selective self sensitive sequence sequences serializable server server_name setof share show simple skip slice snapshot source specific_name sqlcode sqlerror sqrt stable stacked standalone statement statistics stddev_pop stddev_samp stdin stdout storage strict strip structure style subclass_origin submultiset subscription substring substring_regex succeeds sum symmetric sysid system system_time t table_name tables tablesample tablespace temp template ties token top_level_count transaction_active transactions_committed transactions_rolled_back transform transforms translate translate_regex trigger_catalog trigger_name trigger_schema trim trim_array truncate trusted type types uescape unbounded uncommitted unencrypted unlink unlisten unlogged unnamed untyped upper uri use_column use_variable user_defined_type_catalog user_defined_type_code user_defined_type_name user_defined_type_schema vacuum valid validate validator value_of var_pop var_samp varbinary variable_conflict variadic verbose version versioning views volatile warning whitespace width_bucket window within wrapper xmlagg xmlattributes xmlbinary xmlcast xmlcomment xmlconcat xmldeclaration xmldocument xmlelement xmlexists xmlforest xmliterate xmlnamespaces xmlparse xmlpi xmlquery xmlroot xmlschema xmlserialize xmltable xmltext xmlvalidate yes",
+  functions: SQLFunctions + "abs aggregate array_agg array_max_cardinality avg decode encode bernoulli cardinality ceil ceiling char_length character_length coalesce corr degrees substring system xmlcomment xmlvalidate xmlexists length strip lower upper bit_length normalize mod octet_length overlay ln sqrt power exp log lower",
+  keywords: SQLKeywords + "abort absent access according ada admin alias also always analyse analyze asensitive assert assignment asymmetric atomic attach attribute attributes backward base64 begin_frame begin_partition bit_length blocked bom c cache called catalog_name chain character_set_catalog character_set_name character_set_schema characteristics characters checkpoint class class_origin cluster cobol collation_catalog collation_name collation_schema collect column_name columns command_function command_function_code comment comments committed concurrently condition_number configuration conflict connection_name constant constraint_catalog constraint_name constraint_schema contains content control conversion convert copy cost covar_pop covar_samp csv cume_dist current_catalog current_row current_schema cursor_name database datalink datatype datetime_interval_code datetime_interval_precision db debug defaults defined definer degree delimiter delimiters dense_rank depends derived detach detail dictionary disable discard dispatch dlnewcopy dlpreviouscopy dlurlcomplete dlurlcompleteonly dlurlcompletewrite dlurlpath dlurlpathonly dlurlpathwrite dlurlscheme dlurlserver dlvalue document dump dynamic_function dynamic_function_code element elsif empty enable encoding encrypted end_frame end_partition endexec enforced enum errcode error event every exclude excluding exclusive explain expression extension extract family file filter final first_value flag floor following force foreach fortran forward frame_row freeze fs functions fusion g generated granted greatest groups handler header hex hierarchy hint id ignore ilike immediately immutable implementation implicit import include including increment indent index indexes info inherit inherits inline insensitive instance instantiable instead integrity intersection invoker isnull k key_member key_type label lag last_value lead leakproof least length library like_regex link listen load location lock locked logged m mapping matched materialized max max_cardinality maxvalue member merge message message_length message_octet_length message_text min minvalue mode more move multiset mumps name namespace nfc nfd nfkc nfkd nil normalize normalized nothing notice notify notnull nowait nth_value ntile nullable nullif nulls number occurrences_regex octets off offset oids operator options ordering others over overriding owned owner p parallel parameter_mode parameter_name parameter_ordinal_position parameter_specific_catalog parameter_specific_name parameter_specific_schema parser partition pascal passing passthrough password percent percent_rank percentile_cont percentile_disc perform period permission pg_context pg_datatype_name pg_exception_context pg_exception_detail pg_exception_hint placing plans pli policy portion position position_regex precedes preceding prepared print_strict_params procedural procedures program publication query quote raise range rank reassign recheck recovery refresh regr_avgx regr_avgy regr_count regr_intercept regr_r2 regr_slope regr_sxx regr_sxy regr_syy reindex rename repeatable replace replica requiring reset respect restart restore result_oid returned_cardinality returned_length returned_octet_length returned_sqlstate returning reverse routine_catalog routine_name routine_schema routines row_count row_number rowtype rule scale schema_name schemas scope scope_catalog scope_name scope_schema security selective self sensitive sequence sequences serializable server server_name setof share show simple skip slice snapshot source specific_name sqlcode sqlerror stable stacked standalone statement statistics stddev_pop stddev_samp stdin stdout storage strict strip structure style subclass_origin submultiset subscription substring_regex succeeds sum symmetric sysid system system_time t table_name tables tablesample tablespace temp template ties token top_level_count transaction_active transactions_committed transactions_rolled_back transform transforms translate translate_regex trigger_catalog trigger_name trigger_schema trim trim_array truncate trusted type types uescape unbounded uncommitted unencrypted unlink unlisten unlogged unnamed untyped upper uri use_column use_variable user_defined_type_catalog user_defined_type_code user_defined_type_name user_defined_type_schema vacuum valid validate validator value_of var_pop var_samp varbinary variable_conflict variadic verbose version versioning views volatile warning whitespace width_bucket window within wrapper xmlagg xmlattributes xmlbinary xmlcast xmlcomment xmlconcat xmldeclaration xmldocument xmlelement xmlexists xmlforest xmliterate xmlnamespaces xmlparse xmlpi xmlquery xmlroot xmlschema xmlserialize xmltable xmltext xmlvalidate yes",
   types: SQLTypes + "bigint int8 bigserial serial8 varbit bool box bytea cidr circle precision float8 inet int4 json jsonb line lseg macaddr macaddr8 money numeric pg_lsn point polygon float4 int2 smallserial serial2 serial serial4 text timetz timestamptz tsquery tsvector txid_snapshot uuid xml"
 })
 
@@ -269,6 +239,7 @@ export const MySQL = SQLDialect.define({
   spaceAfterDashes: true,
   specialVar: "@?",
   identifierQuotes: "`",
+  functions: SQLFunctions,
   keywords: SQLKeywords + "group_concat " + MySQLKeywords,
   types: MySQLTypes,
   builtin: MySQLBuiltin
@@ -285,6 +256,7 @@ export const MariaSQL = SQLDialect.define({
   spaceAfterDashes: true,
   specialVar: "@?",
   identifierQuotes: "`",
+  functions: SQLFunctions,
   keywords: SQLKeywords + "always generated groupby_concat hard persistent shutdown soft virtual " + MySQLKeywords,
   types: MySQLTypes,
   builtin: MySQLBuiltin
@@ -293,6 +265,7 @@ export const MariaSQL = SQLDialect.define({
 /// SQL dialect for Microsoft [SQL
 /// Server](https://www.microsoft.com/en-us/sql-server).
 export const MSSQL = SQLDialect.define({
+  functions: SQLFunctions,
   keywords: SQLKeywords + "trigger proc view index for add constraint key primary foreign collate clustered nonclustered declare exec go if use index holdlock nolock nowait paglock pivot readcommitted readcommittedlock readpast readuncommitted repeatableread rowlock serializable snapshot tablock tablockx unpivot updlock with",
   types: SQLTypes + "bigint smallint smallmoney tinyint money real text nvarchar ntext varbinary image hierarchyid uniqueidentifier sql_variant xml",
   builtin: "binary_checksum checksum connectionproperty context_info current_request_id error_line error_message error_number error_procedure error_severity error_state formatmessage get_filestream_transaction_context getansinull host_id host_name isnull isnumeric min_active_rowversion newid newsequentialid rowcount_big xact_state object_id",
@@ -302,7 +275,8 @@ export const MSSQL = SQLDialect.define({
 
 /// [SQLite](https://sqlite.org/) dialect.
 export const SQLite = SQLDialect.define({
-  keywords: SQLKeywords + "abort analyze attach autoincrement conflict database detach exclusive fail glob ignore index indexed instead isnull notnull offset plan pragma query raise regexp reindex rename replace temp vacuum virtual",
+  functions: SQLFunctions + "isnull notnull",
+  keywords: SQLKeywords + "abort analyze attach autoincrement conflict database detach exclusive fail glob ignore index indexed instead offset plan pragma query raise regexp reindex rename replace temp vacuum virtual",
   types: SQLTypes + "bool blob long longblob longtext medium mediumblob mediumint mediumtext tinyblob tinyint tinytext text bigint int2 int8 unsigned signed real",
   builtin: "auth backup bail changes clone databases dbinfo dump echo eqp explain fullschema headers help import imposter indexes iotrace lint load log mode nullvalue once print prompt quit restore save scanstats separator shell show stats system tables testcase timeout timer trace vfsinfo vfslist vfsname width",
   operatorChars: "*+-%<>!=&|/~",
@@ -312,6 +286,7 @@ export const SQLite = SQLDialect.define({
 
 /// Dialect for [Cassandra](https://cassandra.apache.org/)'s SQL-ish query language.
 export const Cassandra = SQLDialect.define({
+  functions: "to_timestamp to_unix_timestamp to_date cast abs round sqrt count sum max avg min log log10 now min_timeuuid max_timeuuid current_timestamp current_date current_time current_timeuuid",
   keywords: "add all allow alter and any apply as asc authorize batch begin by clustering columnfamily compact consistency count create custom delete desc distinct drop each_quorum exists filtering from grant if in index insert into key keyspace keyspaces level limit local_one local_quorum modify nan norecursive nosuperuser not of on one order password permission permissions primary quorum rename revoke schema select set storage superuser table three to token truncate ttl two type unlogged update use user users using values where with writetime infinity NaN",
   types: SQLTypes + "ascii bigint blob counter frozen inet list map static text timeuuid tuple uuid varint",
   slashComments: true
@@ -319,6 +294,7 @@ export const Cassandra = SQLDialect.define({
 
 /// [PL/SQL](https://en.wikipedia.org/wiki/PL/SQL) dialect.
 export const PLSQL = SQLDialect.define({
+  functions: SQLFunctions,
   keywords: SQLKeywords + "abort accept access add all alter and any arraylen as asc assert assign at attributes audit authorization avg base_table begin between binary_integer body by case cast char_base check close cluster clusters colauth column comment commit compress connected constant constraint crash create current currval cursor data_base database dba deallocate debugoff debugon declare default definition delay delete desc digits dispose distinct do drop else elseif elsif enable end entry exception exception_init exchange exclusive exists external fast fetch file for force form from function generic goto grant group having identified if immediate in increment index indexes indicator initial initrans insert interface intersect into is key level library like limited local lock log logging loop master maxextents maxtrans member minextents minus mislabel mode modify multiset new next no noaudit nocompress nologging noparallel not nowait number_base of off offline on online only option or order out package parallel partition pctfree pctincrease pctused pls_integer positive positiven pragma primary prior private privileges procedure public raise range raw rebuild record ref references refresh rename replace resource restrict return returning returns reverse revoke rollback row rowid rowlabel rownum rows run savepoint schema segment select separate set share snapshot some space split sql start statement storage subtype successful synonym tabauth table tables tablespace task terminate then to trigger truncate type union unique unlimited unrecoverable unusable update use using validate value values variable view views when whenever where while with work",
   builtin: "appinfo arraysize autocommit autoprint autorecovery autotrace blockterminator break btitle cmdsep colsep compatibility compute concat copycommit copytypecheck define echo editfile embedded feedback flagger flush heading headsep instance linesize lno loboffset logsource longchunksize markup native newpage numformat numwidth pagesize pause pno recsep recsepchar repfooter repheader serveroutput shiftinout show showmode spool sqlblanklines sqlcase sqlcode sqlcontinue sqlnumber sqlpluscompatibility sqlprefix sqlprompt sqlterminator suffix tab term termout timing trimout trimspool ttitle underline verify version wrap",
   types: SQLTypes + "ascii bfile bfilename bigserial bit blob dec long number nvarchar nvarchar2 serial smallint string text uid varchar2 xml",

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -181,7 +181,7 @@ export function keywordCompletionSource(dialect: SQLDialect, upperCase = false):
 
 /// FIXME remove on 1.0 @internal
 export function keywordCompletion(dialect: SQLDialect, upperCase = false): Extension {
-  return dialect.language.data.of({
+  return dialect.sqlLanguage.data.of({
     autocomplete: keywordCompletionSource(dialect, upperCase)
   })
 }
@@ -196,7 +196,7 @@ export function schemaCompletionSource(config: SQLConfig): CompletionSource {
 
 /// FIXME remove on 1.0 @internal
 export function schemaCompletion(config: SQLConfig): Extension {
-  return config.schema ? (config.dialect || StandardSQL).language.data.of({
+  return config.schema ? (config.dialect || StandardSQL).sqlLanguage.data.of({
     autocomplete: schemaCompletionSource(config)
   }) : []
 }

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -9,7 +9,7 @@ import {tokens, Dialect, tokensFor, SQLKeywords, SQLTypes, dialect} from "./toke
 import {completeFromSchema, completeKeywords} from "./complete"
 
 
-const getSqlParser = (dialect: Dialect) => {
+const getSqlParser = () => {
   return baseParser.configure({
     props: [
       indentNodeProp.add({
@@ -49,12 +49,12 @@ export const getParser = (dialect: Dialect) => {
       commentTokens: {line: "--", block: {open: "/*", close: "*/"}},
       closeBrackets: {brackets: ["(", "[", "{", "'", '"', "`"]}
   }
-  const sqlParser = getSqlParser(dialect).configure({
+  const sqlParser = getSqlParser().configure({
     tokenizers: [{from: tokens, to: tokensFor(dialect)}]
   });
   const sqlLanguage = LRLanguage.define({
     name: "sql",
-    parser: getSqlParser(dialect),
+    parser: sqlParser,
     languageData: sqlLangData
   })
 
@@ -156,26 +156,16 @@ export class SQLDialect {
   private constructor(
     /// @internal
     readonly dialect: Dialect,
-    /// The language for this dialect.
+    /// The mixed language for this dialect.
     readonly language: LRLanguage,
     /// The spec used to define this dialect.
     readonly spec: SQLDialectSpec,
-    /// @internal
+    /// The sql language for this dialect.
     readonly sqlLanguage: LRLanguage,
   ) {}
 
   /// Returns the language for this dialect as an extension.
   get extension() { return this.language.extension }
-
-  getLanguageSupport(extensions: { [name: string]: any; }[]) {
-    const sqlLanguageSupport = new LanguageSupport(this.sqlLanguage, [
-      extensions.map((input) => {
-        return this.sqlLanguage.data.of(input)
-      })
-    ])
-    const mixedLanguageSupport = new LanguageSupport(this.language,[sqlLanguageSupport.support]);
-    return mixedLanguageSupport;
-  }
 
   /// Define a new dialect.
   static define(spec: SQLDialectSpec) {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,7 +2,7 @@ import {ExternalTokenizer, InputStream} from "@lezer/lr"
 import {LineComment, BlockComment, String as StringToken, Number, Bits, Bytes, Bool, Null,
         ParenL, ParenR, BraceL, BraceR, BracketL, BracketR, Semi, Dot,
         Operator, Punctuation, SpecialVar, Identifier, QuotedIdentifier,
-        Keyword, Type, Builtin, Whitespace} from "./sql.grammar.terms"
+        Keyword, Type, Builtin, Whitespace, Function} from "./sql.grammar.terms"
 
 const enum Ch {
   Newline = 10,
@@ -118,13 +118,14 @@ function inString(ch: number, str: string) {
 
 const Space = " \t\r\n"
 
-function keywords(keywords: string, types: string, builtin?: string) {
+function keywords(keywords: string, types: string, builtin?: string, functions?: string) {
   let result: {[name: string]: number} = Object.create(null)
   result["true"] = result["false"] = Bool
   result["null"] = result["unknown"] = Null
   for (let kw of keywords.split(" ")) if (kw) result[kw] = Keyword
   for (let tp of types.split(" ")) if (tp) result[tp] = Type
   for (let kw of (builtin || "").split(" ")) if (kw) result[kw] = Builtin
+  for (let kw of (functions || "").split(" ")) if (kw) result[kw] = Function
   return result
 }
 
@@ -145,7 +146,8 @@ export interface Dialect {
 }
 
 export const SQLTypes = "array binary bit boolean char character clob date decimal double float int integer interval large national nchar nclob numeric object precision real smallint time timestamp varchar varying "
-export const SQLKeywords = "absolute action add after all allocate alter and any are as asc assertion at authorization before begin between both breadth by call cascade cascaded case cast catalog check close collate collation column commit condition connect connection constraint constraints constructor continue corresponding count create cross cube current current_date current_default_transform_group current_transform_group_for_type current_path current_role current_time current_timestamp current_user cursor cycle data day deallocate declare default deferrable deferred delete depth deref desc describe descriptor deterministic diagnostics disconnect distinct do domain drop dynamic each else elseif end end-exec equals escape except exception exec execute exists exit external fetch first for foreign found from free full function general get global go goto grant group grouping handle having hold hour identity if immediate in indicator initially inner inout input insert intersect into is isolation join key language last lateral leading leave left level like limit local localtime localtimestamp locator loop map match method minute modifies module month names natural nesting new next no none not of old on only open option or order ordinality out outer output overlaps pad parameter partial path prepare preserve primary prior privileges procedure public read reads recursive redo ref references referencing relative release repeat resignal restrict result return returns revoke right role rollback rollup routine row rows savepoint schema scroll search second section select session session_user set sets signal similar size some space specific specifictype sql sqlexception sqlstate sqlwarning start state static system_user table temporary then timezone_hour timezone_minute to trailing transaction translation treat trigger under undo union unique unnest until update usage user using value values view when whenever where while with without work write year zone "
+export const SQLFunctions = "abs absolute case check cast concat coalesce cube collate count current_date current_path current_role current_time current_timestamp current_user day exists grouping hour localtime localtimestamp minute month second trim session_user size system_user treat unnest user year equals lower upper pow floor ceil exp log ifnull min max avg sum sqrt round "
+export const SQLKeywords = "action add after all allocate alter and any are as asc assertion at authorization before begin between both breadth by call cascade cascaded catalog close collation column commit condition connect connection constraint constraints constructor continue corresponding create cross current current_default_transform_group current_transform_group_for_type cursor cycle data deallocate declare default deferrable deferred delete depth deref desc describe descriptor deterministic diagnostics disconnect distinct do domain drop dynamic each else elseif end end-exec equals escape except exception exec execute exit external fetch first for foreign found from free full function general get global go goto grant group handle having hold identity if immediate in indicator initially inner inout input insert intersect into is isolation join key language last lateral leading leave left level like limit local locator loop map match method modifies module names natural nesting new next no none not of old on only open option or order ordinality out outer output overlaps pad parameter partial path prepare preserve primary prior privileges procedure public read reads recursive redo ref references referencing relative release repeat resignal restrict result return returns revoke right role rollback rollup routine row rows savepoint schema scroll search section select session set sets signal similar some space specific specifictype sql sqlexception sqlstate sqlwarning start state static table temporary then timezone_hour timezone_minute to trailing transaction translation trigger under undo union unique until update usage using value values view when whenever where while with without work write zone "
 
 const defaults: Dialect = {
   backslashEscapes: false,
@@ -160,14 +162,14 @@ const defaults: Dialect = {
   operatorChars: "*+\-%<>!=&|~^/",
   specialVar: "?",
   identifierQuotes: '"',
-  words: keywords(SQLKeywords, SQLTypes)
+  words: keywords(SQLKeywords, SQLTypes, "", SQLFunctions)
 }
 
-export function dialect(spec: Partial<Dialect>, kws?: string, types?: string, builtin?: string): Dialect {
+export function dialect(spec: Partial<Dialect>, kws?: string, types?: string, builtin?: string, functions?: string): Dialect {
   let dialect = {} as Dialect
   for (let prop in defaults)
     (dialect as any)[prop] = ((spec.hasOwnProperty(prop) ? spec : defaults) as any)[prop]
-  if (kws) dialect.words = keywords(kws, types || "", builtin)
+  if (kws) dialect.words = keywords(kws, types || "", builtin, functions)
   return dialect
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -125,7 +125,7 @@ function keywords(keywords: string, types: string, builtin?: string, functions?:
   for (let kw of keywords.split(" ")) if (kw) result[kw] = Keyword
   for (let tp of types.split(" ")) if (tp) result[tp] = Type
   for (let kw of (builtin || "").split(" ")) if (kw) result[kw] = Builtin
-  for (let kw of (functions || "").split(" ")) if (kw) result[kw] = Function
+  for (let fn of (functions || "").split(" ")) if (fn) result[fn] = Function
   return result
 }
 

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -12,9 +12,9 @@ function get(doc: string, conf: SQLConfig & {explicit?: boolean} = {}) {
   let state = EditorState.create({
     doc,
     selection: {anchor: cur},
-    extensions: [dialect.getLanguageSupport([{
+    extensions: [dialect, dialect.sqlLanguage.data.of({
       autocomplete: schemaCompletionSource(Object.assign({dialect}, conf))
-    }])]
+    })]
   })
   let result = state.languageDataAt<CompletionSource>("autocomplete", cur)[0](new CompletionContext(state, cur, !!conf.explicit))
   return result as CompletionResult | null
@@ -147,7 +147,7 @@ describe("SQL completion", () => {
   })
 
   it("supports alternate quoting styles", () => {
-    ist(str(get("select `u|", {dialect: MySQL, schema: schema1})), "products, users")
+    ist(str(get("select `u|", {dialect: MySQL, schema: schema1})), "`products`, `users`")
   })
 
   it("doesn't complete without identifier", () => {

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -13,6 +13,7 @@ function get(doc: string, conf: SQLConfig & {explicit?: boolean} = {}) {
       autocomplete: schemaCompletionSource(Object.assign({dialect}, conf))
     })]
   })
+  console.log('languageDataAt',state.languageDataAt<CompletionSource>("autocomplete", cur))
   let result = state.languageDataAt<CompletionSource>("autocomplete", cur)[0](new CompletionContext(state, cur, !!conf.explicit))
   return result as CompletionResult | null
 }

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -1,5 +1,6 @@
 import ist from "ist"
 import {PostgreSQL, MySQL, SQLDialect} from "@n8n/codemirror-lang-sql"
+import { LRParser } from '@lezer/lr'
 
 const mysqlTokens = MySQL.language
 const postgresqlTokens = PostgreSQL.language
@@ -7,15 +8,26 @@ const bigQueryTokens = SQLDialect.define({
   treatBitsAsBytes: true
 }).language
 
+const parse = (parser: LRParser, input: string) => {
+  const tree = parser.parse(input);
+  const props: Record<string, {tree: unknown}> = (tree as any).props;
+  const key = Object.keys(props)[0];
+  return props[key].tree;
+}
+
+const parseMixed = (parser: LRParser, input: string) => {
+  return parser.parse(input);
+}
+
 describe("Parse MySQL tokens", () => {
   const parser = mysqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
+    ist(parse(parser, "SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
   it("parses unquoted bit-value literals", () => {
-    ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,Whitespace,Bits))')
+    ist(parse(parser, "SELECT 0b01"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 })
 
@@ -23,15 +35,15 @@ describe("Parse PostgreSQL tokens", () => {
   const parser = postgresqlTokens.parser
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
+    ist(parse(parser, "SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
   it("parses quoted bit-value literals", () => {
-    ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
+    ist(parse(parser, "SELECT B'0101'"), 'Script(Statement(Keyword,Whitespace,Bits))')
   })
 
   it("parses double dollar quoted Whitespace literals", () => {
-    ist(parser.parse("SELECT $$hello$$"), 'Script(Statement(Keyword,Whitespace,String))')
+    ist(parse(parser, "SELECT $$hello$$"), 'Script(Statement(Keyword,Whitespace,String))')
   })
 })
 
@@ -39,19 +51,19 @@ describe("Parse BigQuery tokens", () => {
   const parser = bigQueryTokens.parser
 
   it("parses quoted bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
+    ist(parse(parser, "SELECT b'abcd'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses quoted bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
+    ist(parse(parser, 'SELECT b"abcd"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses bytes literals in single quotes", () => {
-    ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
+    ist(parse(parser, "SELECT b'0101'"), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 
   it("parses bytes literals in double quotes", () => {
-    ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
+    ist(parse(parser, 'SELECT b"0101"'), 'Script(Statement(Keyword,Whitespace,Bytes))')
   })
 })
 
@@ -60,56 +72,56 @@ describe("Parse n8n resolvables", () => {
 
   it("parses resolvables with dots inside composite identifiers", () => {
     ist(
-      parser.parse("SELECT my_column FROM {{ 'schema' }}.{{ 'table' }}"),
-      'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,CompositeIdentifier(Resolvable,".",Resolvable)))'
+      parseMixed(parser, "SELECT my_column FROM {{ 'schema' }}.{{ 'table' }}"),
+      'Program(Plaintext,Resolvable,Plaintext,Resolvable)'
     )
     ist(
-      parser.parse("SELECT my_column FROM {{ 'schema' }}.{{ 'table' }}.{{ 'foo' }}"),
-      'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,CompositeIdentifier(Resolvable,".",Resolvable,".",Resolvable)))'
+      parseMixed(parser, "SELECT my_column FROM {{ 'schema' }}.{{ 'table' }}.{{ 'foo' }}"),
+      'Program(Plaintext,Resolvable,Plaintext,Resolvable,Plaintext,Resolvable)'
     )
     ist(
-      parser.parse("SELECT my_column FROM public.{{ 'table' }}"),
-      'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,CompositeIdentifier(Identifier,".",Resolvable)))'
+      parseMixed(parser, "SELECT my_column FROM public.{{ 'table' }}"),
+      'Program(Plaintext,Resolvable)'
     )
     ist(
-      parser.parse("SELECT my_column FROM {{ 'schema' }}.users"),
-      'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,CompositeIdentifier(Resolvable,".",Identifier)))'
+      parseMixed(parser, "SELECT my_column FROM {{ 'schema' }}.users"),
+      'Program(Plaintext,Resolvable,Plaintext)'
     )
   })
 
   it("parses 4-node SELECT variants", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table"), 'Script(Statement(Resolvable,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Identifier))')
+    ist(parseMixed(parser, "{{ 'SELECT' }} my_column FROM my_table"), 'Program(Resolvable,Plaintext)')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table"), 'Script(Statement(Keyword,Whitespace,Resolvable,Whitespace,Keyword,Whitespace,Identifier))')
+    ist(parseMixed(parser, "SELECT {{ 'my_column' }} FROM my_table"), 'Program(Plaintext,Resolvable,Plaintext)')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Resolvable,Whitespace,Identifier))')
+    ist(parseMixed(parser, "SELECT my_column {{ 'FROM' }} my_table"), 'Program(Plaintext,Resolvable,Plaintext)')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }}"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Resolvable))')
+    ist(parseMixed(parser, "SELECT my_column FROM {{ 'my_table' }}"), 'Program(Plaintext,Resolvable)')
   })
 
   it("parses 5-node SELECT variants (with semicolon)", () => {
-    ist(parser.parse("{{ 'SELECT' }} my_column FROM my_table;"), 'Script(Statement(Resolvable,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Identifier,";"))')
+    ist(parseMixed(parser, "{{ 'SELECT' }} my_column FROM my_table;"), 'Program(Resolvable,Plaintext)')
     
-    ist(parser.parse("SELECT {{ 'my_column' }} FROM my_table;"), 'Script(Statement(Keyword,Whitespace,Resolvable,Whitespace,Keyword,Whitespace,Identifier,";"))')
+    ist(parseMixed(parser, "SELECT {{ 'my_column' }} FROM my_table;"), 'Program(Plaintext,Resolvable,Plaintext)')
 
-    ist(parser.parse("SELECT my_column {{ 'FROM' }} my_table;"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Resolvable,Whitespace,Identifier,";"))')
+    ist(parseMixed(parser, "SELECT my_column {{ 'FROM' }} my_table;"), 'Program(Plaintext,Resolvable,Plaintext)')
 
-    ist(parser.parse("SELECT my_column FROM {{ 'my_table' }};"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,Resolvable,";"))')
+    ist(parseMixed(parser, "SELECT my_column FROM {{ 'my_table' }};"), 'Program(Plaintext,Resolvable,Plaintext)')
   })
 
   it("parses single-quoted resolvable with no whitespace", () => {
-    ist(parser.parse("SELECT my_column FROM '{{ 'my_table' }}';"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,OrphanSingleQuote,Resolvable,OrphanSingleQuote,";"))')
+    ist(parseMixed(parser, "SELECT my_column FROM '{{ 'my_table' }}';"), 'Program(Plaintext,Resolvable,Plaintext)')
   });
 
   it("parses single-quoted resolvable with leading whitespace", () => {
-    ist(parser.parse("SELECT my_column FROM ' {{ 'my_table' }}';"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,OrphanSingleQuote,Whitespace,Resolvable,OrphanSingleQuote,";"))')
+    ist(parseMixed(parser, "SELECT my_column FROM ' {{ 'my_table' }}';"), 'Program(Plaintext,Resolvable,Plaintext)')
   });
 
   it("parses single-quoted resolvable with trailing whitespace", () => {
-    ist(parser.parse("SELECT my_column FROM '{{ 'my_table' }} ';"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,OrphanSingleQuote,Resolvable,Whitespace,OrphanSingleQuote,";"))')
+    ist(parseMixed(parser, "SELECT my_column FROM '{{ 'my_table' }} ';"), 'Program(Plaintext,Resolvable,Plaintext)')
   });
 
   it("parses single-quoted resolvable with surrounding whitespace", () => {
-    ist(parser.parse("SELECT my_column FROM ' {{ 'my_table' }} ';"), 'Script(Statement(Keyword,Whitespace,Identifier,Whitespace,Keyword,Whitespace,OrphanSingleQuote,Whitespace,Resolvable,Whitespace,OrphanSingleQuote,";"))')
+    ist(parseMixed(parser, "SELECT my_column FROM ' {{ 'my_table' }} ';"), 'Program(Plaintext,Resolvable,Plaintext)')
   });
 })


### PR DESCRIPTION
This PR makes some fixes related to n8n expression parsing and syntax highlighting.
[Issues](https://linear.app/n8n/issue/NODE-3532/postgres-node-syntax-highlighting-on-execute-query-does-not-respect):
- links in strings are being parsed as sql rather than strings
- functions are not highlighted in a different color

<img width="554" height="410" alt="image" src="https://github.com/user-attachments/assets/daba190e-99b9-471e-858e-edaf2cbfeb02" />

The issue with links is that expressions `{{ }}` were included in SQL grammar and string parsing got broken. The PR reverts sql grammar to it's original state and adds an [overlay language](https://lezer.codemirror.net/docs/guide/#grammar-nesting) that separates sql from n8n expressions.

The PR also adds a new element `Function` to allow highlighting them differently than statements such as `SELECT`. I tried to include the most basic functions, but in reality there are hundreds of functions in each SQL dialect, so it feasible to include them all.

Related to https://github.com/n8n-io/n8n/pull/19291