### PR TITLE
Add warning that repository was moved to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # codemirror-lang-n8n-sql
 
+> [!WARNING]
+> This repository is read-only and has been moved to the n8n monorepo at [`packages/@n8n/codemirror-lang-sql`](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/codemirror-lang-sql).
+
 SQL + n8n expression language support for CodeMirror 6. 
 
 Based on [`@codemirror/lang-sql`](https://github.com/codemirror/lang-sql).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a warning to the README that this repository is read-only and has moved to the n8n monorepo at packages/@n8n/codemirror-lang-sql, so users go to the right place for updates.

<sup>Written for commit bb3b1d3124d79f85af3a8c7c867971698a5ffa72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

